### PR TITLE
Allow overriding the URL, so it's possible to page results

### DIFF
--- a/repositories_api.go
+++ b/repositories_api.go
@@ -141,6 +141,13 @@ func (a *RepositoriesApiService) RepositoriesUsernameGet(ctx context.Context, us
 	if localVarTempParam, localVarOk := localVarOptionals["role"].(string); localVarOk {
 		localVarQueryParams.Add("role", parameterToString(localVarTempParam, ""))
 	}
+
+	// overwrites the url with the passed one, used when paging with "next" / "previous"
+	// https://developer.atlassian.com/bitbucket/api/2/reference/meta/pagination
+	if localVarTempParam, localVarOk := localVarOptionals["override_url"].(string); localVarOk {
+		localVarPath = localVarTempParam
+	}
+
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"application/json"}
 

--- a/teams_api.go
+++ b/teams_api.go
@@ -57,6 +57,13 @@ func (a *TeamsApiService) TeamsGet(ctx context.Context, localVarOptionals map[st
 	if localVarTempParam, localVarOk := localVarOptionals["role"].(string); localVarOk {
 		localVarQueryParams.Add("role", parameterToString(localVarTempParam, ""))
 	}
+	
+	// overwrites the url with the passed one, used when paging with "next" / "previous"
+	// https://developer.atlassian.com/bitbucket/api/2/reference/meta/pagination
+	if localVarTempParam, localVarOk := localVarOptionals["override_url"].(string); localVarOk {
+		localVarPath = localVarTempParam
+	}
+	
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{ "application/json",  }
 


### PR DESCRIPTION
This can maybe be a possible fix for #2  , but maybe there is a much better way of doing it. 
Bit hard to do it "lower" down also, cause `localVarOptionals` isn't passed into the `a.client.prepareRequest` mostly a fix for https://github.com/jenkins-x/jx/issues/1561