### PR TITLE
fix: repository size overflow

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -15,7 +15,6 @@ import (
 )
 
 type Repository struct {
-
 	Type_ string `json:"type"`
 
 	Links *RepositoryLinks `json:"links,omitempty"`
@@ -42,7 +41,7 @@ type Repository struct {
 
 	UpdatedOn time.Time `json:"updated_on,omitempty"`
 
-	Size int32 `json:"size,omitempty"`
+	Size int64 `json:"size,omitempty"`
 
 	Language string `json:"language,omitempty"`
 
@@ -50,7 +49,7 @@ type Repository struct {
 
 	HasWiki bool `json:"has_wiki,omitempty"`
 
-	//  Controls the rules for forking this repository.  * **allow_forks**: unrestricted forking * **no_public_forks**: restrict forking to private forks (forks cannot   be made public later) * **no_forks**: deny all forking 
+	//  Controls the rules for forking this repository.  * **allow_forks**: unrestricted forking * **no_public_forks**: restrict forking to private forks (forks cannot   be made public later) * **no_forks**: deny all forking
 	ForkPolicy string `json:"fork_policy,omitempty"`
 
 	Project *Project `json:"project,omitempty"`


### PR DESCRIPTION
Change repository size from int32 to int64 to accomodate very large repositories.

Fixes this error: `json: cannot unmarshal number 3167593874 into Go struct field Repository.size of type int32`

Unsure if this is the correct way to fix the problem and it is likely a breaking change.  I searched for usages of `Repository.Size` in the JX project and there were none.